### PR TITLE
Use latest as snapshot image to account for concourse upgrade

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -208,6 +208,7 @@ resources:
     icon: cube
     source:
       repository: &test-apps-nodejs-image-name gcr.io/instana-agent-qa/buildpacks/test/nodejs
+      tag: latest
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
@@ -224,6 +225,7 @@ resources:
     icon: cube
     source:
       repository: &test-apps-netcore-image-name gcr.io/instana-agent-qa/buildpacks/test/netcore
+      tag: latest
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
@@ -240,6 +242,7 @@ resources:
     icon: cube
     source:
       repository: &test-apps-java-mvn-image-name gcr.io/instana-agent-qa/buildpacks/test/java-mvn
+      tag: latest
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
@@ -256,6 +259,7 @@ resources:
     icon: cube
     source:
       repository: &test-apps-java-gradle-image-name gcr.io/instana-agent-qa/buildpacks/test/java-gradle
+      tag: latest
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -175,6 +175,7 @@ resources:
       repository: &gcr-deployer-image-name gcr.io/instana-agent-qa/cnb/gcr-deployer
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
+      tag: latest
 
   - name: google-cloud-run-buildpack-snapshot-image
     type: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -159,6 +159,7 @@ resources:
       repository: *git-manipulator-image-name
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
+      tag: latest
 
   - name: gcr-deployer-source
     type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -181,6 +181,7 @@ resources:
       repository: &buildpack-snapshot-image-name gcr.io/instana-agent-qa/buildpacks/cloudrun
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
+      tag: latest
 
   - name: google-cloud-run-buildpack-release-image
     type: registry-image
@@ -870,7 +871,7 @@ jobs:
             source: *gcr-deployer-image
           inputs:
             - name: google-cloud-run-buildpack-build
-          outputs: 
+          outputs:
             - name: buildpack-build
           run:
             path: /bin/bash

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,6 +13,7 @@ var:
       repository: &git-manipulator-image-name gcr.io/instana-agent-qa/cnb/git-manipulator
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
+      tag: latest
 
   e2e-tests-setup:
     gcp-project: &gcp-e2e-tests-project instana-agent-qa
@@ -141,6 +142,7 @@ resources:
       repository: &cnb-package-builder-image-name gcr.io/instana-agent-qa/cnb/package-builder
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
+      tag: latest
 
   - name: git-manipulator-source
     type: git


### PR DESCRIPTION
# Use latest as snapshot image to account for concourse upgrade

## Why

The `registry-image` tag property is now mandatory.
